### PR TITLE
[refactor] Resetting

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ $subscription->featureOverQuota('build.minutes');
 
 By default, each created feature is resettable - each time the billing cycle ends, you can call `resetQuotas` to reset them (they will become 3000 in the previous example).
 
-Make sure to set the reset time after the billing cycle resets.
+Make sure to call `resetQuotas` after the billing cycle resets.
 
 ```php
 Saas::plan('Gold Plan', 'gold-plan')
@@ -247,6 +247,8 @@ Saas::plan('Gold Plan', 'gold-plan')
         Saas::feature('Seats', 'seats', 5)->notResettable(),
     ]);
 ```
+
+Now when calling `resetQuotas()`, the `seats` feature won't go back to the default value.
 
 ## Unlimited amount
 

--- a/README.md
+++ b/README.md
@@ -221,17 +221,22 @@ $subscription->featureOverQuota('build.minutes');
 
 ## Resetting tracked values
 
-By default, each created feature is resettable - each time the billing cycle ends, it resets to the starting value (3000 in the previous example).
+By default, each created feature is resettable - each time the billing cycle ends, you can call `resetQuotas` to reset them (they will become 3000 in the previous example).
 
-Make sure to set the reset time exactly how long the invoice period is for the plan:
+Make sure to set the reset time after the billing cycle resets.
 
 ```php
 Saas::plan('Gold Plan', 'gold-plan')
     ->features([
         Saas::feature('Build Minutes', 'build.minutes', 3000)
-            ->description('3000 build minutes for an entire month')
-            ->resetEvery(30, 'day'),
+            ->description('3000 build minutes for an entire month'),
     ]);
+```
+
+```php
+if ($payment->done()) {
+    $subscription->resetQuotas();
+}
 ```
 
 To avoid resetting, like counting the seats for a subscription, you should call `notResettable()` on the feature:

--- a/database/migrations/2020_01_01_000001_create_subscription_usages_table.php
+++ b/database/migrations/2020_01_01_000001_create_subscription_usages_table.php
@@ -18,7 +18,6 @@ class CreateSubscriptionUsagesTable extends Migration
             $table->string('feature_id');
 
             $table->unsignedSmallInteger('used');
-            $table->timestamp('valid_until')->nullable();
 
             $table->timestamps();
 

--- a/src/Feature.php
+++ b/src/Feature.php
@@ -39,22 +39,11 @@ class Feature implements Arrayable
     protected $value = 0;
 
     /**
-     * The trial period. Works with $invoiceInterval.
-     * For example, this can be 10 if $invoiceInterval
-     * is 'day'.
+     * Mark the feature as being resettable.
      *
-     * @var int
+     * @var bool
      */
-    protected $resetPeriod = 1;
-
-    /**
-     * The interval for the plan basic invoicing.
-     * It can be month, day, etc. This should be
-     * supported by Carbon\Carbon.
-     *
-     * @var string
-     */
-    protected $resetInterval = 'month';
+    protected $resettable = true;
 
     /**
      * Create a new feature builder.
@@ -111,42 +100,13 @@ class Feature implements Arrayable
     }
 
     /**
-     * Set the reset interval for the usability
-     * of this feature.
-     *
-     * @param  int  $period
-     * @param  string  $interval
-     * @return $this
-     */
-    public function reset($period = 0, $interval = 'day')
-    {
-        $this->resetPeriod = $period;
-        $this->resetInterval = $interval;
-
-        return $this;
-    }
-
-    /**
-     * Alias for reset().
-     *
-     * @param  int  $period
-     * @param  string  $interval
-     * @return $this
-     */
-    public function resetEvery($period = 0, $interval = 'day')
-    {
-        return $this->reset($period, $interval);
-    }
-
-    /**
      * Mark the feature as not resettable.
      *
      * @return $this
      */
     public function notResettable()
     {
-        $this->resetPeriod = 0;
-        $this->resetInterval = 'day';
+        $this->resettable = false;
 
         return $this;
     }
@@ -192,33 +152,13 @@ class Feature implements Arrayable
     }
 
     /**
-     * Get the reset period value.
-     *
-     * @return int
-     */
-    public function getResetPeriod(): int
-    {
-        return $this->resetPeriod;
-    }
-
-    /**
-     * Get the reset interval value.
-     *
-     * @return int
-     */
-    public function getResetInterval(): string
-    {
-        return $this->resetInterval;
-    }
-
-    /**
      * Check if this feature is resettable after each billing cycle.
      *
      * @return bool
      */
     public function isResettable(): bool
     {
-        return $this->resetPeriod && $this->resetInterval;
+        return $this->resettable;
     }
 
     /**
@@ -229,18 +169,6 @@ class Feature implements Arrayable
     public function isUnlimited(): bool
     {
         return $this->getValue() < 0;
-    }
-
-    /**
-     * Get feature's reset date.
-     *
-     * @param  string|\Carbon\Carbon|null  $from
-     * @return \Carbon\Carbon
-     */
-    public function getResetDate($from = null): Carbon
-    {
-        return Carbon::parse($from)
-            ->add($this->resetPeriod, $this->resetInterval);
     }
 
     /**
@@ -255,8 +183,6 @@ class Feature implements Arrayable
             'name' => $this->getName(),
             'description' => $this->getDescription(),
             'value' => $this->getValue(),
-            'reset_period' => $this->getResetPeriod(),
-            'reset_interval' => $this->getResetInterval(),
             'unlimited' => $this->isUnlimited(),
             'resettable' => $this->isResettable(),
         ];

--- a/src/Models/Subscription.php
+++ b/src/Models/Subscription.php
@@ -227,8 +227,16 @@ class Subscription extends CashierSubscription
      */
     public function resetQuotas()
     {
-        foreach ($this->usage()->cursor() as $usage) {
-            $usage->delete();
-        }
+        $plan = $this->getPlan();
+
+        $this->usage()
+            ->get()
+            ->each(function (Usage $usage) use ($plan) {
+                $feature = $plan->getFeature($usage->feature_id);
+
+                if ($feature->isResettable()) {
+                    $usage->delete();
+                }
+            });
     }
 }

--- a/src/Models/Subscription.php
+++ b/src/Models/Subscription.php
@@ -227,8 +227,8 @@ class Subscription extends CashierSubscription
      */
     public function resetQuotas()
     {
-        foreach ($this->getPlan()->getFeatures() as $feature) {
-            $this->setFeatureUsage($feature->getId(), 0);
+        foreach ($this->usage()->cursor() as $usage) {
+            $usage->delete();
         }
     }
 }

--- a/src/Models/Subscription.php
+++ b/src/Models/Subscription.php
@@ -48,14 +48,6 @@ class Subscription extends CashierSubscription
             'feature_id' => $feature->getId(),
         ]);
 
-        if ($feature->isResettable()) {
-            $usage->fill([
-                'valid_until' => is_null($usage->ends_at)
-                    ? $feature->getResetDate($this->created_at)
-                    : $feature->getResetDate($this->ends_at),
-            ]);
-        }
-
         $usage->fill([
             'used' => $incremental ? $usage->used + $value : $value,
         ]);
@@ -127,11 +119,7 @@ class Subscription extends CashierSubscription
             ->whereFeatureId($id)
             ->first();
 
-        if (! $usage) {
-            return 0;
-        }
-
-        return $usage->expired() ? 0 : $usage->used;
+        return $usage ? $usage->used: 0;
     }
 
     /**
@@ -230,5 +218,17 @@ class Subscription extends CashierSubscription
     public function featureOverQuota(string $id): bool
     {
         return $this->featureOverflown($id);
+    }
+
+    /**
+     * Reset the quotas of this subscription.
+     *
+     * @return void
+     */
+    public function resetQuotas()
+    {
+        foreach ($this->getPlan()->getFeatures() as $feature) {
+            $this->setFeatureUsage($feature->getId(), 0);
+        }
     }
 }

--- a/src/Models/Usage.php
+++ b/src/Models/Usage.php
@@ -16,14 +16,7 @@ class Usage extends Model
      */
     protected $fillable = [
         'subscription_id', 'feature_id',
-        'used', 'valid_until',
-    ];
-
-    /**
-     * {@inheritdoc}
-     */
-    protected $dates = [
-        'valid_until',
+        'used',
     ];
 
     /**
@@ -44,19 +37,5 @@ class Usage extends Model
     public function subscription()
     {
         return $this->belongsTo(config('saas.cashier.models.subscription'));
-    }
-
-    /**
-     * Check whether usage has been expired or not.
-     *
-     * @return bool
-     */
-    public function expired(): bool
-    {
-        if (is_null($this->valid_until)) {
-            return false;
-        }
-
-        return now()->gte($this->valid_until);
     }
 }

--- a/tests/FeatureTest.php
+++ b/tests/FeatureTest.php
@@ -98,7 +98,7 @@ class FeatureTest extends TestCase
             50, $subscription->getUsedQuota('build.minutes')
         );
 
-        Carbon::setTestNow(now()->addMonths(1));
+        $subscription->resetQuotas();
 
         $this->assertEquals(
             0, $subscription->getUsedQuota('build.minutes')

--- a/tests/FeatureTest.php
+++ b/tests/FeatureTest.php
@@ -109,6 +109,31 @@ class FeatureTest extends TestCase
         );
     }
 
+    public function test_feature_usage_on_resetting_not_resettable()
+    {
+        $user = factory(User::class)->create();
+
+        $plan = Saas::getPlan(static::$planId);
+
+        $subscription = $user->newSubscription('main', static::$planId)->create('pm_card_visa');
+
+        $subscription->recordFeatureUsage('teams', 1);
+
+        $this->assertEquals(
+            1, $subscription->getUsedQuota('teams')
+        );
+
+        $subscription->resetQuotas();
+
+        $this->assertEquals(
+            1, $subscription->getUsedQuota('teams')
+        );
+
+        $this->assertEquals(
+            9, $subscription->getRemainingQuota('teams')
+        );
+    }
+
     public function test_record_inexistent_feature_usage()
     {
         $user = factory(User::class)->create();

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -44,7 +44,7 @@ abstract class TestCase extends Orchestra
 
         Saas::plan('Monthly $10', static::$planId)
             ->features([
-                Saas::feature('Build Minutes', 'build.minutes', 3000)->resetEvery(30, 'day'),
+                Saas::feature('Build Minutes', 'build.minutes', 3000),
                 Saas::feature('Seats', 'teams', 10)->notResettable(),
             ]);
     }


### PR DESCRIPTION
This PR adds breaking changes to the overall functionality for resettable features.

- Removed `valid_until` from `subscription_usages` table
- Removed `reset()`, `resetEvery()`, `getResetPeriod()` and `getResetInterval()` from feature definitions
- Removed `expired()` check from the `Usage` model

- Introducing `resetQuotas()` to reset the quotas after each billing cycle.
- Features are resettable by default. The `notResettable()` method still exists.