### PR TITLE
Update doctrine/dbal dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "doctrine/dbal": "^2.9|^2.12",
+        "doctrine/dbal": "^2.12",
         "laravel/framework": "^7.0|^8.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "doctrine/dbal": "^2.9",
+        "doctrine/dbal": "^2.9|^2.12",
         "laravel/framework": "^7.0|^8.0"
     },
     "autoload": {


### PR DESCRIPTION
In order to install it along the latest laravel horizon, it needs to be updated.