### PR TITLE
Add Contract for Usage, to make Usage independent from Eloquent Model

### DIFF
--- a/src/Concerns/HasQuotas.php
+++ b/src/Concerns/HasQuotas.php
@@ -3,7 +3,6 @@
 namespace RenokiCo\CashierRegister\Concerns;
 
 use RenokiCo\CashierRegister\Feature;
-use RenokiCo\CashierRegister\Models\Usage;
 use RenokiCo\CashierRegister\Saas;
 
 trait HasQuotas
@@ -207,7 +206,7 @@ trait HasQuotas
 
         $this->usage()
             ->get()
-            ->each(function (Usage $usage) use ($plan) {
+            ->each(function ($usage) use ($plan) {
                 $feature = $plan->getFeature($usage->feature_id);
 
                 if ($feature->isResettable()) {


### PR DESCRIPTION
The goal of this PR is to make the Usage model independent from the Eloquent model. The usage model is configurable, but still, it must be extended from the Eloquent model. In case when we want to use Mongo DB, we wish to be able to extend the Mongo model.

The source of the issue is the type check in the HasQuotas -> `resetQuotas` method. I send this solution with a new Contract for Usage. Please note that everyone who wants to replace Usage with its own model it has to implement `ContractUsage`.

Another approach would be not to do the type checking at all.

The original issue is #18 